### PR TITLE
Fix for Vapor 4.5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "7f6c8277b8cbe4381d00ddcef3b898c820780324",
-          "version": "4.4.0"
+          "revision": "c70d45fe9cce525df5b5f4793a232596cd85484b",
+          "version": "4.5.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["VaporTypedRoutes"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", .upToNextMajor(from: "4.4.0")),
+        .package(url: "https://github.com/vapor/vapor.git", .upToNextMajor(from: "4.5.0")),
     ],
     targets: [
         .target(

--- a/Sources/VaporTypedRoutes/RoutesBuilder+RouteContext.swift
+++ b/Sources/VaporTypedRoutes/RoutesBuilder+RouteContext.swift
@@ -74,7 +74,7 @@ extension RoutesBuilder {
 
         let responder = BasicResponder { request in
             if case .collect(let max) = body, request.body.data == nil {
-                return request.body.collect(max: max?.value).flatMapThrowing { _ in
+                return request.body.collect(max: max?.value ?? request.application.routes.defaultMaxBodySize.value).flatMapThrowing { _ in
                     return try wrappingClosure(request)
                 }.encodeResponse(for: request)
             } else {

--- a/Sources/VaporTypedRoutes/RoutesBuilder+RouteContext.swift
+++ b/Sources/VaporTypedRoutes/RoutesBuilder+RouteContext.swift
@@ -74,7 +74,7 @@ extension RoutesBuilder {
 
         let responder = BasicResponder { request in
             if case .collect(let max) = body, request.body.data == nil {
-                return request.body.collect(max: max).flatMapThrowing { _ in
+                return request.body.collect(max: max?.value).flatMapThrowing { _ in
                     return try wrappingClosure(request)
                 }.encodeResponse(for: request)
             } else {


### PR DESCRIPTION
Apparently the type of `max` was changed to `BytesCount` with Vapor 4.5.0.
This fix allows VaporTypedRoutes to compile with Vapor 4.5.0 and it is working for me.