### PR TITLE
Add Typed Headers to RequestContext

### DIFF
--- a/Sources/VaporTypedRoutes/Header.swift
+++ b/Sources/VaporTypedRoutes/Header.swift
@@ -1,0 +1,103 @@
+//
+//  Header.swift
+//  
+//
+//  Created by Charlie Welsh on 9/18/22.
+//
+
+import Vapor
+
+/// A type that represents an abstract header in a request.
+public protocol AbstractHeader {
+    /// The name of the header.
+    var name: String { get }
+    /// A list of allowed values, if any.
+    ///
+    /// Defaults to allowing anything.
+    var allowedValues: [String]? { get }
+    /// A description of the query parameter.
+    ///
+    /// Useful for documentation generation.
+    var description: String? { get }
+
+    /// The associated Swift type for the query parameter.
+    var swiftType: Any.Type { get }
+}
+
+/// A type that represents a concrete query parameter in a request, with an associated type.
+public protocol HeaderProtocol: AbstractHeader {
+    /// The associated Swift type for the header.
+    associatedtype SwiftType
+
+    /// The default value of the header, if any.
+    var defaultValue: SwiftType? { get }
+}
+
+extension HeaderProtocol {
+    public var swiftType: Any.Type {
+        return SwiftType.self
+    }
+}
+
+/// A concrete header with an associated Swift type.
+public struct Header<T: Decodable>: HeaderProtocol {
+    public typealias SwiftType = T
+
+    public let name: String
+    public let allowedValues: [String]?
+    public let description: String?
+    public let defaultValue: T?
+
+    /// Creates a new header instance with the constituent elements, allowing all values.
+    /// - Parameters:
+    ///   - name: The name of the header (e.g, the part before the colon).
+    ///   - description: An optional description of the header (for documentation generation and the like).
+    ///   - defaultValue: An optional default value to use when a request doesn't provide one.
+    public init(name: String, description: String? = nil, defaultValue: T? = nil) {
+        self.name = name
+        self.allowedValues = nil
+        self.defaultValue = defaultValue
+        self.description = description
+    }
+
+    /// Creates a new parameter instance with the constituent elements, specifying a finite list of allowed values.
+    /// - Parameters:
+    ///   - name: The name of the header (e.g, the part before the colon).
+    ///   - description: An optional description of the header (for documentation generation and the like).
+    ///   - defaultValue: An optional default value to use when a request doesn't provide one.
+    ///   - allowedValues: A finite list of allowed values.
+    public init<U: LosslessStringConvertible>(name: String, description: String? = nil, defaultValue: T? = nil, allowedValues: [U]) {
+        self.name = name
+        self.description = description
+        self.defaultValue = defaultValue
+        self.allowedValues = allowedValues.map(String.init(describing:))
+    }
+}
+
+/// A header with a single value.
+///
+/// e.x.
+///
+///     Header-Name: hello
+public typealias StringHeader = Header<String>
+
+/// A header with a single value (must be an integer).
+///
+/// e.x.
+///
+///     Header-Name: 1
+public typealias IntegerHeader = Header<Int>
+
+/// A header with a single value (must be number, not necessarily an integer)
+///
+/// e.x.
+///
+///     Header-Name: 10.345
+public typealias NumberHeader = Header<Double>
+
+/// A header where the value is a comma-separated list of values.
+///
+/// e.x. (`CSVHeader<String>`)
+///
+///     Header-Name: hello,world
+public typealias CSVHeader<SwiftType: Decodable> = Header<[SwiftType]>

--- a/Sources/VaporTypedRoutes/TypedRequest+Header.swift
+++ b/Sources/VaporTypedRoutes/TypedRequest+Header.swift
@@ -1,0 +1,66 @@
+//
+//  TypedRequest+Header.swift
+//  
+//
+//  Created by Charlie Welsh on 9/18/22.
+//
+
+import Vapor
+
+extension TypedRequest {
+    /// An object containing the various
+    @dynamicMemberLookup
+    public final class Headers {
+        /// The parent request.
+        private unowned var typedRequest: TypedRequest
+        /// The context for the request.
+        private let context: Context = .shared
+
+        /// Initialize from a given TypedRequest instance.
+        init(request: TypedRequest) {
+            self.typedRequest = request
+        }
+
+        /// Get a string value for a given header.
+        private func getString(at name: String) -> String? {
+            return typedRequest
+                .underlyingRequest
+                .headers.first(name: name)
+        }
+
+        /// Get an array of strings for a given comma-separated header.
+        private func getStringArray(at name: String) -> [String]? {
+            return getString(at: name)?
+                .split(separator: ",")
+                .map(String.init)
+        }
+
+        /// Get a single query value using a given key path in the associated `Context` object.
+        /// - Parameters:
+        ///   - dynamicMember: A `KeyPath` from the `Context` object to a `QueryParam`.
+        public subscript<T: LosslessStringConvertible>(dynamicMember path: KeyPath<Context, Header<T>>) -> T? {
+            return getString(at: context[keyPath: path].name)
+                .flatMap(T.init) ?? context[keyPath: path].defaultValue
+        }
+
+        /// Get an array of values using a given key path to an array in the associated `Context` object.
+        /// - Parameters:
+        ///   - dynamicMember: A `KeyPath` from the `Context` object to a `QueryParam` where the value is an array.
+        public subscript<T: LosslessStringConvertible>(dynamicMember path: KeyPath<Context, Header<[T]>>) -> [T]? {
+            return getStringArray(at: context[keyPath: path].name)?
+                .compactMap(T.init) ?? context[keyPath: path].defaultValue
+        }
+
+        // TODO: add better support for dictionary
+        //      needs modifications to or replacement of the default
+        //      parser which throws fatal error if requesting a path
+        //      that is not in the query params.
+        //        public subscript(dynamicMember path: KeyPath<Context, NestedQueryParam<String>>) -> String? {
+        //            return typedRequest
+        //                .underlyingRequest
+        //                .query[String.self, at: context[keyPath: path].path]
+        //                ?? context[keyPath: path].defaultValue
+        //        }
+    }
+}
+

--- a/Sources/VaporTypedRoutes/TypedRequest.swift
+++ b/Sources/VaporTypedRoutes/TypedRequest.swift
@@ -15,6 +15,7 @@ public final class TypedRequest<Context: RouteContext> {
     private let request: Request
 
     public private(set) lazy var query: Query = Query(request: self)
+    public private(set) lazy var header: Headers = Headers(request: self)
     public private(set) lazy var response = ResponseBuilder<Context>(request: self)
 
     public subscript<T>(dynamicMember path: KeyPath<Request, T>) -> T {

--- a/Tests/VaporTypedRoutesTests/VaporTypedRoutesTests.swift
+++ b/Tests/VaporTypedRoutesTests/VaporTypedRoutesTests.swift
@@ -10,27 +10,7 @@ final class VaporTypedRoutesTests: XCTestCase {
 
         app.routes.get("hello", use: TestController.showRoute)
 
-        try app.testable().test(.GET, "/hello", afterResponse:  { res in
-            XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.headers.contentType, .plainText)
-            XCTAssertEqual(res.body.string, "Hello")
-        })
-
-        try app.testable().test(.GET, "/hello?failHard=t", afterResponse:  { res in
-            print(res)
-            let resBodyData = Data(buffer: res.body)
-            print(String(data: resBodyData, encoding: .utf8)!)
-
-            XCTAssertEqual(res.status, .badRequest)
-            XCTAssertEqual(res.headers.contentType, .plainText)
-            XCTAssertEqual(res.body.string, "")
-        })
-
-        try app.testable().test(.GET, "/hello?echo=10", afterResponse:  { res in
-            XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.headers.contentType, .plainText)
-            XCTAssertEqual(res.body.string, "10")
-        })
+        try test(on: app)
     }
 
     @available(macOS 12, *)
@@ -40,19 +20,63 @@ final class VaporTypedRoutesTests: XCTestCase {
 
         app.routes.get("hello", use: AsyncTestController.showRoute)
 
-        try app.testable().test(.GET, "/hello", afterResponse:  { res in
+        try test(on: app)
+    }
+
+    /// The shared test requests.
+    func test(on app: Application) throws {
+        try app.testable().test(.GET, "/hello", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.headers.contentType, .plainText)
             XCTAssertEqual(res.body.string, "Hello")
         })
 
-        try app.testable().test(.GET, "/hello?failHard=t", afterResponse:  { res in
+        try app.testable().test(.GET, "/hello", beforeRequest: { req in
+            req.headers = [
+                "String-Header": "exampletext"
+            ]
+        }, afterResponse:  { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.headers.contentType, .plainText)
+            XCTAssertEqual(res.body.string, "exampletext")
+        })
+
+        // Check that the header won't accept an incorrect type
+        try app.testable().test(.GET, "/hello", beforeRequest: { req in
+            req.headers = [
+                "Int-Header": "exampletext"
+            ]
+        }, afterResponse:  { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.headers.contentType, .plainText)
+            XCTAssertEqual(res.body.string, "Hello")
+        })
+
+        // Check that the header won't accept an incorrect type
+        try app.testable().test(.GET, "/hello", beforeRequest: { req in
+            req.headers = [
+                "Int-Header": "2"
+            ]
+        }, afterResponse:  { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.headers.contentType, .plainText)
+            XCTAssertEqual(res.body.string, "Int 2")
+        })
+
+        try app.testable().test(.GET, "/hello?failHard=t", afterResponse: { res in
             XCTAssertEqual(res.status, .badRequest)
             XCTAssertEqual(res.headers.contentType, .plainText)
             XCTAssertEqual(res.body.string, "")
         })
 
-        try app.testable().test(.GET, "/hello?echo=10", afterResponse:  { res in
+        // Check that the query param won't accept an incorrect type
+        try app.testable().test(.GET, "/hello?echo=a21f", afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.headers.contentType, .plainText)
+            XCTAssertEqual(res.body.string, "Hello")
+        })
+
+        try app.testable().test(.GET, "/hello?echo=10", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.headers.contentType, .plainText)
             XCTAssertEqual(res.body.string, "10")
@@ -69,6 +93,9 @@ struct TestShowRouteContext: RouteContext {
 
     let badQuery: StringQueryParam = .init(name: "failHard")
     let echo: IntegerQueryParam = .init(name: "echo")
+
+    let stringHeader: StringHeader = .init(name: "String-Header")
+    let intHeader: IntegerHeader = .init(name: "Int-Header")
 
     let success: ResponseContext<String> = .init { response in
         response.headers = Self.plainTextHeader
@@ -93,6 +120,12 @@ final class TestController {
         if req.query.badQuery != nil {
             return req.response.badRequest
         }
+        // Check headers with higher precedence
+        if let header = req.header.stringHeader {
+            return req.response.success.encode(header)
+        } else if let header = req.header.intHeader {
+            return req.response.success.encode("Int \(header)")
+        }
         if let text = req.query.echo {
             return req.response.success.encode("\(text)")
         }
@@ -105,6 +138,12 @@ final class AsyncTestController {
         if req.query.badQuery != nil {
             // This is clunky but I don't see a better option because subscripts can't be async
             return try await req.response.get(\.badRequest)
+        }
+        // Check headers with higher precedence
+        if let header = req.header.stringHeader {
+            return try await req.response.success.encode(header)
+        } else if let header = req.header.intHeader {
+            return try await req.response.success.encode("Int \(header)")
         }
         if let text = req.query.echo {
             return try await req.response.success.encode("\(text)")


### PR DESCRIPTION
This PR should add typed headers to VaporTypedRoutes, which is the first step to solving mattpolzin/VaporOpenAPI#11.